### PR TITLE
Add recursive argument to write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
-- Nothing yet
+- `WheelFile.write` and `WheelFile.write_data` now accept a `recursive`
+  keyword-only argument, which makes both of them recursively add the whole
+  directory subtree, if the `filename` argument was pointing at one.
 
 ### Changed
+- `WheelFile.write` and `WheelFile.write_data` are recursive by default.
 - Backported support to python 3.6
 
 ## [0.0.3] - 2021-03-28

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -545,3 +545,14 @@ class TestWheelFileRecursiveWrite:
         assert all(
             path.startswith(custom_arcname) for path in wf.zipfile.namelist()
         )
+
+    def test_write_data_writes_recursively_when_asked(self, wf, path_tree):
+        directory = path_tree[0]
+        directory_name = os.path.basename(directory.rstrip('/'))
+        archive_root = '_-0.data/test/' + directory_name + '/'
+
+        wf.write_data(directory, section="test", recursive=True)
+
+        expected_tree = [archive_root + pth[len(directory):]
+                         for pth in path_tree]
+        assert set(wf.zipfile.namelist()) == set(expected_tree)

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -492,3 +492,6 @@ class TestWheelFileDistDataWrite:
 class TestWheelFileRecursiveWrite:
     def test_write_has_recursive_arg(self, wf, tmp_path):
         wf.write(tmp_path, recursive=True)
+
+    def test_recursive_write_does_not_break_on_files(self, wf, tmp_file):
+        wf.write(tmp_file, recursive=True)

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -487,3 +487,8 @@ class TestWheelFileDistDataWrite:
 
     def test_mode_is_written_to_mode_attribute(self, wf):
         assert wf.mode == 'w'
+
+
+class TestWheelFileRecursiveWrite:
+    def test_write_has_recursive_arg(self, wf, tmp_path):
+        wf.write(tmp_path, recursive=True)

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -556,3 +556,13 @@ class TestWheelFileRecursiveWrite:
         expected_tree = [archive_root + pth[len(directory):]
                          for pth in path_tree]
         assert set(wf.zipfile.namelist()) == set(expected_tree)
+
+    def test_write_data_writes_non_recursively_when_asked(self, wf, path_tree):
+        directory = path_tree[0]
+        directory_name = os.path.basename(directory.rstrip('/'))
+        archive_root = '_-0.data/test/' + directory_name + '/'
+
+        wf.write_data(directory, section="test", recursive=False)
+
+        expected_tree = [archive_root]
+        assert wf.zipfile.namelist() == expected_tree

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -495,3 +495,9 @@ class TestWheelFileRecursiveWrite:
 
     def test_recursive_write_does_not_break_on_files(self, wf, tmp_file):
         wf.write(tmp_file, recursive=True)
+
+    def test_write_data_has_recursive_arg(self, wf, tmp_path):
+        wf.write_data(tmp_path, 'section', recursive=True)
+
+    def test_recursive_write_data_does_not_break_on_files(self, wf, tmp_file):
+        wf.write_data(tmp_file, 'section', recursive=True)

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1490,6 +1490,13 @@ class WheelFile:
                                  stem: str, arcname: Optional[str]):
         if arcname is None:
             arcname = prefix
+
+        # Ensure that os.path.join will not get an absolute path after cutting
+        # 'prefix' out of 'directory'.
+        # Otherwise cutting out 'prefix' might've left out leading '/', which
+        # would make os.path.join below ignore 'arcname'.
+        prefix = prefix.rstrip(os.sep) + os.sep
+
         path = os.path.join(arcname, directory[len(prefix):], stem)
         return path
 

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1437,7 +1437,7 @@ class WheelFile:
     def write(self,
               filename: Union[str, Path],
               arcname: Optional[str] = None,
-              recursive: bool = True) -> None:
+              *, recursive: bool = True) -> None:
         """Add the file to the wheel.
 
         Updates the wheel record, if the record is being kept.
@@ -1453,9 +1453,9 @@ class WheelFile:
             path separators and the drive letter (if any) will be removed.
 
         recursive
-            When True, if given path leads to a directory, all of its contents
-            are going to be added into the archive, including contents of its
-            subdirectories.
+            Keyword only. When True, if given path leads to a directory, all of
+            its contents are going to be added into the archive, including
+            contents of its subdirectories.
 
             If its False, only a directory entry is going to be added, without
             any of tis contents.
@@ -1506,7 +1506,7 @@ class WheelFile:
     # ZipInfo.from_file does it
     def write_data(self, filename: Union[str, Path],
                    section: str, arcname: Optional[str] = None,
-                   recursive: bool = True) -> None:
+                   *, recursive: bool = True) -> None:
         """Write a file to the .data directory under a specified section.
 
         This method is a handy shortcut for writing into
@@ -1531,9 +1531,9 @@ class WheelFile:
             filename is used. Leading slashes are stripped.
 
         recursive
-            When True, if given path leads to a directory, all of its contents
-            are going to be added into the archive, including contents of its
-            subdirectories.
+            Keyword only. When True, if given path leads to a directory, all of
+            its contents are going to be added into the archive, including
+            contents of its subdirectories.
 
             If its False, only a directory entry is going to be added, without
             any of tis contents.

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1467,7 +1467,6 @@ class WheelFile:
         # actually used by ZipFile, and for RECORD we need the latter
         # FIXME: this means that ZipInfo.from_file is called twice, wastefully
         arcname = ZipInfo.from_file(filename, arcname).filename
-
         self.refresh_record(arcname)
 
         if recursive:

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1579,7 +1579,7 @@ class WheelFile:
         arcname = self._distinfo_path(section + '/' + arcname.lstrip('/'),
                                       kind='data')
 
-        self.write(filename, arcname)
+        self.write(filename, arcname, recursive=recursive)
 
     # TODO: compression args?
     # TODO: drive letter should be stripped from the arcname the same way

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1465,7 +1465,7 @@ class WheelFile:
 
         # The arcname given to write may not be the same as the arcname
         # actually used by ZipFile, and for RECORD we need the latter
-        # FIXME: this means that ZipInfo.from_file is called twice
+        # FIXME: this means that ZipInfo.from_file is called twice, wastefully
         arcname = ZipInfo.from_file(filename, arcname).filename
 
         self.refresh_record(arcname)

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1436,7 +1436,7 @@ class WheelFile:
     def write(self,
               filename: Union[str, Path],
               arcname: Optional[str] = None,
-              recursive: bool = False) -> None:
+              recursive: bool = True) -> None:
         """Add the file to the wheel.
 
         Updates the wheel record, if the record is being kept.

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1444,12 +1444,20 @@ class WheelFile:
         Parameters
         ----------
         filename
-            Path to the file to add.
+            Path to the file or directory to add.
 
         arcname
             Path in the archive to assign the file into. If not given,
             `filename` will be used instead. In both cases, the leading path
             separators and the drive letter (if any) will be removed.
+
+        recursive
+            When True, if given path leads to a directory, all of its contents
+            are going to be added into the archive, including contents of its
+            subdirectories.
+
+            If its False, only a directory entry is going to be added, without
+            any of tis contents.
         """
         self._zip.write(filename, arcname=arcname)
 
@@ -1507,7 +1515,7 @@ class WheelFile:
         Parameters
         ----------
         filename
-            Path to the file to add.
+            Path to the file or directory to add.
 
         section
             Name of the section, i.e. the directory inside `.data/` that the
@@ -1518,6 +1526,14 @@ class WheelFile:
             Path in the archive to assign the file into, relative to the
             directory of the specified data section. If left empty, filename is
             used. Leading slashes are stripped.
+
+        recursive
+            When True, if given path leads to a directory, all of its contents
+            are going to be added into the archive, including contents of its
+            subdirectories.
+
+            If its False, only a directory entry is going to be added, without
+            any of tis contents.
         """
         self._check_section(section)
 

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1503,7 +1503,8 @@ class WheelFile:
     # TODO: drive letter should be stripped from the arcname the same way
     # ZipInfo.from_file does it
     def write_data(self, filename: Union[str, Path],
-                   section: str, arcname: Optional[str] = None) -> None:
+                   section: str, arcname: Optional[str] = None,
+                   recursive: bool = True) -> None:
         """Write a file to the .data directory under a specified section.
 
         This method is a handy shortcut for writing into

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1473,8 +1473,12 @@ class WheelFile:
             common_root = str(filename)
             root_arcname = arcname
             for root, dirs, files in os.walk(filename):
+                # For reproducibility, sort directories, so that os.walk
+                # traverses them in a defined order.
+                dirs.sort()
+
                 dirs = [d + '/' for d in dirs]
-                for name in dirs + files:
+                for name in sorted(dirs + files):
                     filepath = os.path.join(root, name)
                     arcpath = self._os_walk_path_to_arcpath(
                         common_root, root, name, root_arcname

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1433,6 +1433,7 @@ class WheelFile:
         return self._zip.fp is None
 
     # TODO: compression args?
+    # TODO: symlinks?
     def write(self,
               filename: Union[str, Path],
               arcname: Optional[str] = None,
@@ -1501,6 +1502,7 @@ class WheelFile:
 
     # TODO: compression args?
     # TODO: drive letter should be stripped from the arcname the same way
+    # TODO: symlinks?
     # ZipInfo.from_file does it
     def write_data(self, filename: Union[str, Path],
                    section: str, arcname: Optional[str] = None,

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1435,7 +1435,8 @@ class WheelFile:
     # TODO: compression args?
     def write(self,
               filename: Union[str, Path],
-              arcname: Optional[str] = None) -> None:
+              arcname: Optional[str] = None,
+              recursive: bool = False) -> None:
         """Add the file to the wheel.
 
         Updates the wheel record, if the record is being kept.

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -1447,9 +1447,9 @@ class WheelFile:
             Path to the file or directory to add.
 
         arcname
-            Path in the archive to assign the file into. If not given,
-            `filename` will be used instead. In both cases, the leading path
-            separators and the drive letter (if any) will be removed.
+            Path in the archive to assign the file/directory into. If not
+            given, `filename` will be used instead. In both cases, the leading
+            path separators and the drive letter (if any) will be removed.
 
         recursive
             When True, if given path leads to a directory, all of its contents
@@ -1524,9 +1524,9 @@ class WheelFile:
             Cannot contain any slashes, nor be empty.
 
         arcname
-            Path in the archive to assign the file into, relative to the
-            directory of the specified data section. If left empty, filename is
-            used. Leading slashes are stripped.
+            Path in the archive to assign the file/directory into, relative to
+            the directory of the specified data section. If left empty,
+            filename is used. Leading slashes are stripped.
 
         recursive
             When True, if given path leads to a directory, all of its contents


### PR DESCRIPTION
- [x] `write` and `write_data` have `recursive` kwargs
- [x] docstrings for `recursive arg`
- [x] with `recursive=True` and a directory in `filename`, `write` walks over every file in the subtree and adds it accordingly
- [x] `write_data` passes `recursive` to `write`
- [x] no exceptions are raised when a plain file is given and `recursive=True`
- [x] `arcname`, if given, sets correct archive name for the directory
- [x] what order should the files be added in?