### PR TITLE
Backporting support to python 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Nothing yet
 
 ### Changed
-- Nothing yet
+- Backported support to python 3.6
 
 ## [0.0.3] - 2021-03-28
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+mypy_path=stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 packaging ~= 20.8
+zipfile38 ; python_version<"3.8"

--- a/stubs/zipfile38.pyi
+++ b/stubs/zipfile38.pyi
@@ -1,0 +1,170 @@
+import io
+import sys
+from _typeshed import StrPath
+from types import TracebackType
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Pattern,
+    Protocol,
+    Sequence,
+    Text,
+    Tuple,
+    Type,
+    Union,
+)
+
+_SZI = Union[Text, ZipInfo]
+_DT = Tuple[int, int, int, int, int, int]
+
+class BadZipFile(Exception): ...
+BadZipfile = BadZipFile
+
+error = BadZipfile
+
+class LargeZipFile(Exception): ...
+
+class ZipExtFile(io.BufferedIOBase):
+    MAX_N: int = ...
+    MIN_READ_SIZE: int = ...
+
+    MAX_SEEK_READ: int = ...
+
+    newlines: Optional[List[bytes]]
+    mode: str
+    name: str
+    def __init__(
+        self, fileobj: IO[bytes], mode: str, zipinfo: ZipInfo, pwd: Optional[bytes] = ..., close_fileobj: bool = ...
+    ) -> None: ...
+    def read(self, n: Optional[int] = ...) -> bytes: ...
+    def readline(self, limit: int = ...) -> bytes: ...  # type: ignore
+    def __repr__(self) -> str: ...
+    def peek(self, n: int = ...) -> bytes: ...
+    def read1(self, n: Optional[int]) -> bytes: ...  # type: ignore
+
+class _Writer(Protocol):
+    def write(self, __s: str) -> Any: ...
+
+class ZipFile:
+    filename: Optional[Text]
+    debug: int
+    comment: bytes
+    filelist: List[ZipInfo]
+    fp: Optional[IO[bytes]]
+    NameToInfo: Dict[Text, ZipInfo]
+    start_dir: int  # undocumented
+    def __init__(
+        self,
+        file: Union[StrPath, IO[bytes]],
+        mode: str = ...,
+        compression: int = ...,
+        allowZip64: bool = ...,
+        compresslevel: Optional[int] = ...,
+        *,
+        strict_timestamps: bool = ...,
+    ) -> None: ...
+    def __enter__(self) -> ZipFile: ...
+    def __exit__(
+        self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
+    ) -> None: ...
+    def close(self) -> None: ...
+    def getinfo(self, name: Text) -> ZipInfo: ...
+    def infolist(self) -> List[ZipInfo]: ...
+    def namelist(self) -> List[Text]: ...
+    def open(self, name: _SZI, mode: Text = ..., pwd: Optional[bytes] = ..., *, force_zip64: bool = ...) -> IO[bytes]: ...
+    def extract(self, member: _SZI, path: Optional[StrPath] = ..., pwd: Optional[bytes] = ...) -> str: ...
+    def extractall(
+        self, path: Optional[StrPath] = ..., members: Optional[Iterable[Text]] = ..., pwd: Optional[bytes] = ...
+    ) -> None: ...
+    def printdir(self, file: Optional[_Writer] = ...) -> None: ...
+    def setpassword(self, pwd: bytes) -> None: ...
+    def read(self, name: _SZI, pwd: Optional[bytes] = ...) -> bytes: ...
+    def testzip(self) -> Optional[str]: ...
+    def write(
+        self,
+        filename: StrPath,
+        arcname: Optional[StrPath] = ...,
+        compress_type: Optional[int] = ...,
+        compresslevel: Optional[int] = ...,
+    ) -> None: ...
+    def writestr(
+        self,
+        zinfo_or_arcname: _SZI,
+        data: Union[bytes, str],
+        compress_type: Optional[int] = ...,
+        compresslevel: Optional[int] = ...,
+    ) -> None: ...
+
+class PyZipFile(ZipFile):
+    def __init__(
+        self,
+        file: Union[str, IO[bytes]],
+        mode: str = ...,
+        compression: int = ...,
+        allowZip64: bool = ...,
+        optimize: int = ...,
+    ) -> None: ...
+    def writepy(self, pathname: str, basename: str = ..., filterfunc: Optional[Callable[[str], bool]] = ...) -> None: ...
+
+class ZipInfo:
+    filename: Text
+    date_time: _DT
+    compress_type: int
+    comment: bytes
+    extra: bytes
+    create_system: int
+    create_version: int
+    extract_version: int
+    reserved: int
+    flag_bits: int
+    volume: int
+    internal_attr: int
+    external_attr: int
+    header_offset: int
+    CRC: int
+    compress_size: int
+    file_size: int
+    def __init__(self, filename: Optional[Text] = ..., date_time: Optional[_DT] = ...) -> None: ...
+    @classmethod
+    def from_file(cls, filename: StrPath, arcname: Optional[StrPath] = ..., *, strict_timestamps: bool = ...) -> ZipInfo: ...
+    def is_dir(self) -> bool: ...
+    def FileHeader(self, zip64: Optional[bool] = ...) -> bytes: ...
+
+class Path:
+    @property
+    def name(self) -> str: ...
+    @property
+    def parent(self) -> Path: ...  # undocumented
+    def __init__(self, root: Union[ZipFile, StrPath, IO[bytes]], at: str = ...) -> None: ...
+    def open(self, mode: str = ..., pwd: Optional[bytes] = ..., *, force_zip64: bool = ...) -> IO[bytes]: ...
+    def iterdir(self) -> Iterator[Path]: ...
+    def is_dir(self) -> bool: ...
+    def is_file(self) -> bool: ...
+    def exists(self) -> bool: ...
+    def read_text(
+        self,
+        encoding: Optional[str] = ...,
+        errors: Optional[str] = ...,
+        newline: Optional[str] = ...,
+        line_buffering: bool = ...,
+        write_through: bool = ...,
+    ) -> str: ...
+    def read_bytes(self) -> bytes: ...
+    def joinpath(self, add: StrPath) -> Path: ...  # undocumented
+    def __truediv__(self, add: StrPath) -> Path: ...
+
+def is_zipfile(filename: Union[StrPath, IO[bytes]]) -> bool: ...
+
+ZIP_STORED: int
+ZIP_DEFLATED: int
+ZIP64_LIMIT: int
+ZIP_FILECOUNT_LIMIT: int
+ZIP_MAX_COMMENT: int
+ZIP_BZIP2: int
+ZIP_LZMA: int

--- a/tests/test_wheel_gen.py
+++ b/tests/test_wheel_gen.py
@@ -1,8 +1,14 @@
 import pytest
 
+import sys
+
 from io import BytesIO
 from wheelfile import WheelFile
-from zipfile import ZipFile, Path as ZipPath
+
+if sys.version_info >= (3,8):
+    from zipfile import ZipFile, Path as ZipPath
+else:
+    from zipfile38 import ZipFile, Path as ZipPath
 
 
 class TestEmptyWheelStructure:

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -1,13 +1,18 @@
 import pytest
 
 import os
+import sys
 
 from functools import partial
 from wheelfile import WheelFile, UnnamedDistributionError, BadWheelFileError
 from io import BytesIO
 from packaging.version import Version
 from pathlib import Path
-from zipfile import ZipFile, Path as ZipPath, ZipInfo
+
+if sys.version_info >= (3,8):
+    from zipfile import ZipFile, ZipInfo, Path as ZipPath
+else:
+    from zipfile38 import ZipFile, ZipInfo, Path as ZipPath
 
 
 def test_UnnamedDistributionError_is_BadWheelFileError():

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -19,6 +19,7 @@ Here's how to create a simple package under a specific directory path::
 # Which python3 versions should we target? 3.6+ seems like a good idea.
 import csv
 import io
+import sys
 import hashlib
 import base64
 
@@ -32,7 +33,11 @@ from packaging.version import Version, InvalidVersion
 from email.message import EmailMessage
 from email.policy import EmailPolicy
 from email import message_from_string
-from zipfile import ZipFile, ZipInfo
+
+if sys.version_info >= (3,8):
+    from zipfile import ZipFile, ZipInfo
+else:
+    from zipfile38 import ZipFile, ZipInfo
 
 from typing import Optional, Union, List, Dict, IO, BinaryIO
 


### PR DESCRIPTION
At line 656 in wheelfile.py the following was causing heartache on python 3.6.  Python 3.7 added the tell method on zipfile.ZipExtFile which is the actual type for buf as called from line 1371.
```python
assert buf.tell() == 0, (
    f"Stale buffer given - current position: {buf.tell()}."
)
```
Additionally several tests use zipfile.Path which wasn't added until Python 3.8.

By adding a dependency on zipfile38 (which is a backport of zipfile from Python 3.8, if you couldn't guess :P ) all the zipfile dependencies just kind of resolve themselves.  zipfile38 is not typed so I pulled the zipfile.pyi from typeshed and modified it so that it would always assume it was running on a Python 3.8 environment which is what zipfile38 provides.  So both the mypy tests and pytests all pass

I ran the following to test on Python 3.6
```bash
docker run -it -v ~/wheelfile:/wheelfile python:3.6-buster /bin/bash
python -m pip install -r wheelfile/requirements-dev.txt
pytest wheelfile/
mypy wheelfile/
```
I've verified it works on Python 3.7 too using the same method.