### PR TITLE
Adding EntryPoint support to wheelfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Nothing yet.
+- Added support for entry\_points.txt files.
 
 ## [0.0.8] - 2021-08-03
 ### Changed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,10 @@ Metadata classes
     :special-members:
     :members:
 
+.. autoclass:: EntryPoints
+    :special-members:
+    :members:
+
 Exceptions
 ----------
 .. autoexception:: BadWheelFileError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 packaging ~= 20.8
 zipfile38 ; python_version<"3.8"
+importlib-metadata>=1.4.0 ; python_version<"3.8"

--- a/tests/test_metas.py
+++ b/tests/test_metas.py
@@ -421,7 +421,9 @@ class TestEntryPoints:
         assert str(entry_points) == expected
 
     def test_one_with_attr_and_extra(self, entry_points):
-        entry_points.add(EntryPoint(name="foo", value="bar:quux [frob]", group="baz"))
+        entry_points.add(EntryPoint(name="foo",
+                                    value="bar:quux [frob]",
+                                    group="baz"))
 
         expected = dedent("""\
             [baz]

--- a/tests/test_metas.py
+++ b/tests/test_metas.py
@@ -2,6 +2,7 @@ import pytest
 
 from wheelfile import (__version__ as lib_version,
                        WheelData, MetaData, WheelRecord,
+                       EntryPoints, EntryPoint,
                        UnsupportedHashTypeError,
                        RecordContainsDirectoryError,
                        )
@@ -388,3 +389,96 @@ class TestWheelRecord:
         with pytest.raises(RecordContainsDirectoryError):
             record_str = "./,sha256=whatever,0"
             WheelRecord.from_str(record_str)
+
+
+class TestEntryPoints:
+
+    @pytest.fixture
+    def entry_points(self):
+        return EntryPoints()
+
+    def test_empty(self, entry_points):
+        assert str(entry_points) == ''
+
+    def test_one_simple(self, entry_points):
+        entry_points.add(EntryPoint(name="foo", value="bar", group="baz"))
+
+        expected = dedent("""\
+            [baz]
+            foo = bar\n
+        """)
+
+        assert str(entry_points) == expected
+
+    def test_one_with_attr(self, entry_points):
+        entry_points.add(EntryPoint(name="foo", value="bar:quux", group="baz"))
+
+        expected = dedent("""\
+            [baz]
+            foo = bar:quux\n
+        """)
+
+        assert str(entry_points) == expected
+
+    def test_one_with_attr_and_extra(self, entry_points):
+        entry_points.add(EntryPoint(name="foo", value="bar:quux [frob]", group="baz"))
+
+        expected = dedent("""\
+            [baz]
+            foo = bar:quux [frob]\n
+        """)
+
+        assert str(entry_points) == expected
+
+    def test_two_sorted_name(self, entry_points):
+        entry_points.add(EntryPoint(name="b", value="b", group="c"))
+        entry_points.add(EntryPoint(name="a", value="b", group="c"))
+
+        expected = dedent("""\
+            [c]
+            a = b
+            b = b\n
+        """)
+
+        assert str(entry_points) == expected
+
+    def test_two_sorted_group(self, entry_points):
+        entry_points.add(EntryPoint(name="a", value="b", group="c"))
+        entry_points.add(EntryPoint(name="a", value="b", group="a"))
+
+        expected = dedent("""\
+            [a]
+            a = b
+
+            [c]
+            a = b\n
+        """)
+
+        assert str(entry_points) == expected
+
+    def test_from_str_empty(self):
+        entry_points = EntryPoints.from_str("")
+
+        assert len(entry_points) == 0
+
+    def test_from_str_one_simple(self):
+        entry_points = EntryPoints.from_str(dedent("""\
+            [baz]
+            foo = bar
+        """))
+
+        assert EntryPoint("foo", "bar", "baz") in entry_points
+        assert len(entry_points) == 1
+
+    def test_from_str_two_groups_simple(self):
+        entry_points = EntryPoints.from_str(dedent("""\
+            [c]
+            a = b
+
+            [a]
+            a = b\n\n\n
+        """))
+
+        assert EntryPoint("a", "b", "a") in entry_points
+        assert EntryPoint("a", "b", "c") in entry_points
+        assert len(entry_points) == 2

--- a/tests/test_wheel_gen.py
+++ b/tests/test_wheel_gen.py
@@ -115,6 +115,7 @@ class TestWritesDoNotMisformatRecordWithDirEntries:
         wf = WheelFile(buf, 'r', distname='mywheel', version='1')
         assert str(written_dir) not in str(wf.record)
 
+
 class TestEntryPointsMetadata:
 
     distname = 'my_dist'

--- a/tests/test_wheel_gen.py
+++ b/tests/test_wheel_gen.py
@@ -1,8 +1,9 @@
 import pytest
 
 import sys
+from textwrap import dedent
 
-from wheelfile import WheelFile
+from wheelfile import WheelFile, EntryPoint
 
 if sys.version_info >= (3, 8):
     from zipfile import ZipFile, Path as ZipPath
@@ -113,3 +114,32 @@ class TestWritesDoNotMisformatRecordWithDirEntries:
 
         wf = WheelFile(buf, 'r', distname='mywheel', version='1')
         assert str(written_dir) not in str(wf.record)
+
+class TestEntryPointsMetadata:
+
+    distname = 'my_dist'
+    version = '1.0.0'
+
+    @pytest.fixture
+    def wheelfile(self, buf):
+        wf = WheelFile(buf, 'w', distname=self.distname, version=self.version)
+        wf.entry_points.add(EntryPoint("foo", "bar", "baz"))
+        wf.close()
+        return wf
+
+    @pytest.fixture
+    def wheel(self, wheelfile, buf):
+        assert not buf.closed
+        return ZipFile(buf)
+
+    @pytest.fixture
+    def distinfo(self, wheel):
+        return ZipPath(wheel, f'{self.distname}-{self.version}.dist-info/')
+
+    def test_entry_points_is_in_wheelfile(self, distinfo, wheelfile):
+        """Test long lines in METADATA aren't split to multiple shorter lines"""
+        entry_points_txt = distinfo / 'entry_points.txt'
+        assert dedent("""\
+            [baz]
+            foo = bar
+        """) in entry_points_txt.read_text()

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -21,6 +21,8 @@ else:
     from zipfile38 import (ZipFile, ZipInfo, Path as ZipPath, ZIP_DEFLATED,
                            ZIP_BZIP2, ZIP_STORED)
 
+metadata_files = ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt')
+
 
 def test_UnnamedDistributionError_is_BadWheelFileError():
     assert issubclass(UnnamedDistributionError, BadWheelFileError)
@@ -421,7 +423,7 @@ class TestWheelFileWrites:
         di_arcpath = wf.distname + '-' + str(wf.version) + '.dist-info'
         assert wf.zipfile.namelist() == [di_arcpath + '/custom_filename']
 
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
+    @pytest.mark.parametrize('filename', metadata_files)
     def test_write_distinfo_doesnt_permit_writing_metadata(self, wf,
                                                            tmp_path, filename):
         (tmp_path/filename).touch()
@@ -438,14 +440,14 @@ class TestWheelFileWrites:
             wf.write_distinfo(tmp_file, arcname='../file')
 
     @pytest.mark.xfail
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
+    @pytest.mark.parametrize('filename', metadata_files)
     def test_write_doesnt_permit_writing_metadata(self, wf, tmp_path, filename):
         (tmp_path/filename).touch()
         with pytest.raises(ProhibitedWriteError):
             wf.write(tmp_path/filename)
 
     @pytest.mark.xfail
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
+    @pytest.mark.parametrize('filename', metadata_files)
     def test_writestr_doesnt_permit_writing_metadata(self, wf, filename):
         with pytest.raises(ProhibitedWriteError):
             wf.writestr(filename, b'')
@@ -463,12 +465,12 @@ class TestWheelFileWrites:
         wf.writestr_distinfo(zi, data)
         assert wf.zipfile.read(wf.distinfo_dirname + '/' + arcname) == data
 
-    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
+    @pytest.mark.parametrize('name', metadata_files)
     def test_writestr_distinfo_doesnt_permit_writing_metadata(self, wf, name):
         with pytest.raises(ProhibitedWriteError):
             wf.writestr_distinfo(name, b'')
 
-    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
+    @pytest.mark.parametrize('name', metadata_files)
     def test_writestr_distinfo_doesnt_permit_writing_metadata_as_dirs(self,
                                                                       wf, name):
         with pytest.raises(ProhibitedWriteError):
@@ -751,7 +753,7 @@ class TestWheelFileNameList:
         wf.writestr(arcpath, b'contents')
         assert wf.namelist() == [arcpath]
 
-    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
+    @pytest.mark.parametrize("meta_file", metadata_files)
     def test_after_closing_does_not_contain_meta_files(self, wf, meta_file):
         wf.close()
         assert (wf.distinfo_dirname + '/' + meta_file) not in wf.namelist()
@@ -767,14 +769,14 @@ class TestWheelFileInfoList:
         infolist = wf.infolist()
         assert len(infolist) == 1 and infolist[0].filename == arcpath
 
-    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
+    @pytest.mark.parametrize("meta_file", metadata_files)
     def test_after_closing_does_not_contain_meta_files(self, wf, meta_file):
         wf.close()
         infolist_arcpaths = [zi.filename for zi in wf.infolist()]
         assert (wf.distinfo_dirname + '/' + meta_file) not in infolist_arcpaths
 
 
-@pytest.mark.parametrize('metadata_name', ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
+@pytest.mark.parametrize('metadata_name', metadata_files)
 def test_wheelfile_METADATA_FILENAMES(metadata_name):
     assert metadata_name in WheelFile.METADATA_FILENAMES
 

--- a/tests/test_wheelfile.py
+++ b/tests/test_wheelfile.py
@@ -97,6 +97,12 @@ class TestWheelFileInit:
     def test_record_is_empty_after_creation(self, wf):
         assert str(wf.record) == ''
 
+    def test_entry_points_are_created(self, wf):
+        assert wf.entry_points is not None
+
+    def test_entry_points_are_empty_after_creation(self, wf):
+        assert len(wf.entry_points) == 0
+
     def test_if_given_empty_distname_raises_ValueError(self, buf):
         with pytest.raises(ValueError):
             WheelFile(buf, 'w', distname='', version='0')
@@ -257,6 +263,10 @@ class TestWheelFileClose:
         wf.close()
         assert '_-0.dist-info/WHEEL' in wf.record
 
+    def test_no_adds_empty_entry_points_to_record(self, wf):
+        wf.close()
+        assert '_-0.dist-info/entry_points.txt' not in wf.record
+
     def test_sets_closed(self, wf):
         assert not wf.closed
         wf.close()
@@ -411,7 +421,7 @@ class TestWheelFileWrites:
         di_arcpath = wf.distname + '-' + str(wf.version) + '.dist-info'
         assert wf.zipfile.namelist() == [di_arcpath + '/custom_filename']
 
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD'))
+    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
     def test_write_distinfo_doesnt_permit_writing_metadata(self, wf,
                                                            tmp_path, filename):
         (tmp_path/filename).touch()
@@ -428,14 +438,14 @@ class TestWheelFileWrites:
             wf.write_distinfo(tmp_file, arcname='../file')
 
     @pytest.mark.xfail
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD'))
+    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
     def test_write_doesnt_permit_writing_metadata(self, wf, tmp_path, filename):
         (tmp_path/filename).touch()
         with pytest.raises(ProhibitedWriteError):
             wf.write(tmp_path/filename)
 
     @pytest.mark.xfail
-    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD'))
+    @pytest.mark.parametrize('filename', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
     def test_writestr_doesnt_permit_writing_metadata(self, wf, filename):
         with pytest.raises(ProhibitedWriteError):
             wf.writestr(filename, b'')
@@ -453,12 +463,12 @@ class TestWheelFileWrites:
         wf.writestr_distinfo(zi, data)
         assert wf.zipfile.read(wf.distinfo_dirname + '/' + arcname) == data
 
-    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD'))
+    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
     def test_writestr_distinfo_doesnt_permit_writing_metadata(self, wf, name):
         with pytest.raises(ProhibitedWriteError):
             wf.writestr_distinfo(name, b'')
 
-    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD'))
+    @pytest.mark.parametrize('name', ('WHEEL', 'METADATA', 'RECORD', 'entry_points.txt'))
     def test_writestr_distinfo_doesnt_permit_writing_metadata_as_dirs(self,
                                                                       wf, name):
         with pytest.raises(ProhibitedWriteError):
@@ -741,7 +751,7 @@ class TestWheelFileNameList:
         wf.writestr(arcpath, b'contents')
         assert wf.namelist() == [arcpath]
 
-    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL'])
+    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
     def test_after_closing_does_not_contain_meta_files(self, wf, meta_file):
         wf.close()
         assert (wf.distinfo_dirname + '/' + meta_file) not in wf.namelist()
@@ -757,14 +767,14 @@ class TestWheelFileInfoList:
         infolist = wf.infolist()
         assert len(infolist) == 1 and infolist[0].filename == arcpath
 
-    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL'])
+    @pytest.mark.parametrize("meta_file", ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
     def test_after_closing_does_not_contain_meta_files(self, wf, meta_file):
         wf.close()
         infolist_arcpaths = [zi.filename for zi in wf.infolist()]
         assert (wf.distinfo_dirname + '/' + meta_file) not in infolist_arcpaths
 
 
-@pytest.mark.parametrize('metadata_name', ['METADATA', 'RECORD', 'WHEEL'])
+@pytest.mark.parametrize('metadata_name', ['METADATA', 'RECORD', 'WHEEL', 'entry_points.txt'])
 def test_wheelfile_METADATA_FILENAMES(metadata_name):
     assert metadata_name in WheelFile.METADATA_FILENAMES
 

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -21,11 +21,12 @@
 
 Use :class:`WheelFile` to create or read a wheel.
 
-Managing metadata is done via `metadata`, `wheeldata`, `record`, and `entry_points`
-attributes.
+Managing metadata is done via `metadata`, `wheeldata`, `record`, and
+`entry_points` attributes.
 
-See :class:`MetaData`, :class:`WheelData`, :class:`WheelRecord`, and :class:`EntryPoints`
-for documentation of the objects returned by these attributes.
+See :class:`MetaData`, :class:`WheelData`, :class:`WheelRecord`, and
+:class:`EntryPoints` for documentation of the objects returned by these
+attributes.
 
 Example
 -------
@@ -753,10 +754,12 @@ class WheelRecord:
     def __contains__(self, path):
         return path in self._records
 
+
 class EntryPoints(set):
     """Contains logic for creation and modification of entry_points.txt files.
 
-    For the full spec, see https://packaging.python.org/specifications/entry-points/.
+    For the full spec, see
+    https://packaging.python.org/specifications/entry-points/.
     """
 
     def __str__(self) -> str:
@@ -781,22 +784,30 @@ class EntryPoints(set):
 
         return entries
 
+
 class _EntryPointFileParser(configparser.ConfigParser):
     """A config parser customized to read and write entry_points.txt files"""
-    optionxform = staticmethod(str)
+    optionxform = staticmethod(str)  # type: ignore
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, delimiters=('=',), empty_lines_in_values=False, interpolation=None)
+        super().__init__(*args,
+                         **kwargs,
+                         delimiters=('=',),
+                         empty_lines_in_values=False,
+                         interpolation=None)
 
     def getentry_point(self, section, option) -> EntryPoint:
         """Get an EntryPoint object from the entry_points.txt file"""
-        return EntryPoint(group=section, name=option, value=self.get(section, option))
+        return EntryPoint(group=section,
+                          name=option,
+                          value=self.get(section, option))
 
     def setentry_point(self, entry_point: EntryPoint):
         if not self.has_section(entry_point.group):
             self.add_section(entry_point.group)
 
         self.set(entry_point.group, entry_point.name, entry_point.value)
+
 
 class UnsupportedHashTypeError(ValueError):
     """The given hash name is not allowed by the spec."""
@@ -1695,8 +1706,10 @@ class WheelFile:
             self.record = None
 
         try:
-            entry_points = self.zipfile.read(self._distinfo_path('entry_points.txt'))
-            self.entry_points = EntryPoints.from_str(entry_points.decode('utf-8'))
+            entry_points = self.zipfile.read(
+                self._distinfo_path('entry_points.txt'))
+            self.entry_points = EntryPoints.from_str(
+                entry_points.decode('utf-8'))
         except Exception:
             self.entry_points = None
 

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -758,6 +758,8 @@ class WheelRecord:
 class EntryPoints(set):
     """Contains logic for creation and modification of entry_points.txt files.
 
+    Provides a set-like interface to add wheelfile.EntryPoint objects
+
     For the full spec, see
     https://packaging.python.org/specifications/entry-points/.
     """


### PR DESCRIPTION
I added a new object to parse and write entry_points.txt to a wheelfile.

I added an entry_points attribute to the WheelFile object.  The entry_points attribute is an EntryPoints class which provides a set interface for importlib.metadata.EntryPoint objects.  But it has a `__str__`method and a `from_str`method similarly to the other metadata type handlers.

Please take a look, I'm open to all feedback. 