### PR TITLE
Allow RECORD in subfolders, such as what is provided in 'py', which c…

### DIFF
--- a/wheelfile.py
+++ b/wheelfile.py
@@ -699,7 +699,8 @@ class WheelRecord:
         assert buf.tell() == 0, (
             f"Stale buffer given - current position: {buf.tell()}."
         )
-        assert not arcpath.endswith('.dist-info/RECORD'), (
+        # if .dist-info/RECORD is not in a subdirectory, it is not allowed
+        assert "/" in arcpath.replace('.dist-info/RECORD',"") or not arcpath.endswith('.dist-info/RECORD') (
             f"Attempt to add an entry for a RECORD file to the RECORD: "
             f"{repr(arcpath)}."
         )

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -700,7 +700,7 @@ class WheelRecord:
             f"Stale buffer given - current position: {buf.tell()}."
         )
         # if .dist-info/RECORD is not in a subdirectory, it is not allowed
-        assert "/" in arcpath.replace('.dist-info/RECORD',"") or not arcpath.endswith('.dist-info/RECORD') (
+        assert "/" in arcpath.replace('.dist-info/RECORD',"") or not arcpath.endswith('.dist-info/RECORD'), (
             f"Attempt to add an entry for a RECORD file to the RECORD: "
             f"{repr(arcpath)}."
         )


### PR DESCRIPTION
…ontained vendored dependencies

Without this, I get an exception when trying to update a wheel for the package `py`.

The reason is that `py` includes vendored dependencies. This patch allows having that. 
The error I get is: 
```
Exception: Traceback (most recent call last):
  File "/home/mboisson/git/wheels_builder/manipulate_wheels.py", line 84, in main
    wf2 = WheelFile.from_wheelfile(wf, file_or_path=TMP_DIR, version=version)
  File "/cvmfs/soft.computecanada.ca/custom/python/envs/manipulate_wheels/lib/python3.8/site-packages/wheelfile.py", line 1484, in from_wheelfile
    new_wf.writestr(zinfo, wf.zipfile.read(zinfo))
  File "/cvmfs/soft.computecanada.ca/custom/python/envs/manipulate_wheels/lib/python3.8/site-packages/wheelfile.py", line 2051, in writestr
    self.refresh_record(arcname)
  File "/cvmfs/soft.computecanada.ca/custom/python/envs/manipulate_wheels/lib/python3.8/site-packages/wheelfile.py", line 1828, in refresh_record
    self.record.update(arcname, zf)
  File "/cvmfs/soft.computecanada.ca/custom/python/envs/manipulate_wheels/lib/python3.8/site-packages/wheelfile.py", line 727, in update
    assert not arcpath.endswith('.dist-info/RECORD'), (
AssertionError: Attempt to add an entry for a RECORD file to the RECORD: 'py/_vendored_packages/apipkg-2.0.0.dist-info/RECORD'.
``` 

This replaces #19 