### PR TITLE
fix bugged example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ spec = {
 }
 
 requirements = [
-    'packaging ~= 20.8'
+    'packaging ~= 20.8',
     'zipfile38 ; python_version<"3.8"'
 ]
 


### PR DESCRIPTION
without this you get quite a strange requirement line in the wheelfile METADATA:
```
Requires-Dist: packaging ~= 20.8zipfile38 ; python_version<"3.8"
```
that also suggests wheelfile is not really doing proper validation on the requires because 
```
>>> import packaging.requirements
>>> packaging.requirements.Requirement('packaging ~= 20.8zipfile38 ; python_version<"3.8"')
...
packaging.requirements.InvalidRequirement: Parse error at "'zipfile3'": Expected string_end
```