### PR TITLE
build: implement pep621 with example build file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-                  python -m pip install -r requirements-dev.txt
-                  python -m pip install -r requirements.txt
+                  python -m pip install '.[test]'
+                  python -m pip install '.'
             - name: Test with pytest
               run: |
                   pytest

--- a/__build__.py
+++ b/__build__.py
@@ -1,48 +1,70 @@
-from wheelfile import WheelFile, __version__
+import tarfile
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 
-# For WheelFile.__init__
-# Platform, abi, and language tags stay as defaults: "py3-none-any"
-spec: Dict[str, Any] = {
-    'distname': 'wheelfile',
-    'version': __version__
-}
+import toml
+from wheelfile import WheelFile
 
-# Fetch requirements into a list of strings
-requirements = Path('./requirements.txt').read_text().splitlines()
 
-# Open a new wheel file
-with WheelFile(mode='w', **spec) as wf:
-    # Add requirements to the metadata
-    wf.metadata.requires_dists = requirements
-    # We target Python 3.6+ only
-    wf.metadata.requires_python = '>=3.6'
+def get_config() -> Dict[str, Any]:
+    """Read pyproject.toml"""
+    project_config = toml.load('pyproject.toml')
+    config = project_config['project']
+    return config
 
-    # Make sure PyPI page renders nicely
-    wf.metadata.summary = "API for inspecting and creating .whl files"
-    wf.metadata.description = Path('./README.md').read_text()
-    wf.metadata.description_content_type = 'text/markdown'
 
-    # Keywords and trove classifiers, for better searchability
-    wf.metadata.keywords = ['wheel', 'packaging', 'pip', 'build', 'distutils']
-    wf.metadata.classifiers = [
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Topic :: Software Development :: Build Tools',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: System :: Archiving :: Packaging',
-        'Topic :: System :: Software Distribution',
-        'Topic :: Utilities',
-    ]
+def build_sdist(
+    sdist_directory: str, config_settings: Dict[str, Any] = None
+) -> str:
+    config = get_config()
+    name = config['name']
+    version = config['version']
+    distname = f'{name}-{version}'
+    filename = f'{distname}.tar.gz'
+    filepath = Path(sdist_directory) / filename
 
-    # Let the world know who is responsible for this
-    wf.metadata.author = "Błażej Michalik"
-    wf.metadata.home_page = 'https://github.com/MrMino/wheelfile'
+    with tarfile.open(filepath, 'w:gz', format=tarfile.PAX_FORMAT) as sdist:
+        sdist.add('./', arcname=distname, filter=None)
+        return filename
 
-    # Add the code - it will install inside site-packages/wheelfile.py
-    wf.write('./wheelfile.py')
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: Optional[Dict[str, Any]] = None,
+    metadata_directory: Optional[str] = None
+) -> str:
+    config = get_config()
+
+    # For WheelFile.__init__
+    # Platform, abi, and language tags stay as defaults: "py3-none-any"
+    spec: Dict[str, Any] = {
+        'distname': config['name'],
+        'version': config['version']
+    }
+
+    # Open a new wheel file
+    with WheelFile(mode='w', **spec) as wf:
+        # Add requirements to the metadata
+        wf.metadata.requires_dists = config['dependencies']
+        # We target Python 3.6+ only
+        wf.metadata.requires_python = config['requires-python']
+
+        # Make sure PyPI page renders nicely
+        wf.metadata.summary = config['description']
+        wf.metadata.description = Path(config['readme']).read_text()
+        wf.metadata.description_content_type = 'text/markdown'
+
+        # Keywords and trove classifiers, for better searchability
+        wf.metadata.keywords = config['keywords']
+        wf.metadata.classifiers = config['classifiers']
+
+        # Let the world know who is responsible for this
+        wf.metadata.author = config['authors'][0]['name']
+        wf.metadata.home_page = config['urls']['repository']
+
+        # Add the code - it will install inside site-packages/wheelfile.py
+        wf.write('./wheelfile.py')
+        return wf.filename
 
 # Done!
 # 🧀

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx
-furo

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,0 @@
-[mypy]
-mypy_path=stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,80 @@
+[build-system]
+requires = ["wheelfile", "toml"]
+build-backend = "__build__"
+backend-path = ["."]
+
+[project]
+name = "wheelfile"
+version = "0.0.8-1"
+description = "API for creating and inspecting Python .whl files (wheels)."
+readme = "README.md"
+license = {file = "LICENSE"}
+keywords = ["wheel", "packaging", "pip", "build"]
+requires-python = ">=3.6.2"
+authors = [{name = "Błażej Michalik"}]
+maintainers = [{name = "Błażej Michalik"}]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Archiving :: Packaging",
+    "Topic :: System :: Software Distribution",
+    "Topic :: Utilities",
+]
+dependencies = [
+    "packaging~=20.8",
+    "zipfile38; python_version<'3.8'"
+]
+
+[project.optional-dependencies]
+build = [
+    "build",
+]
+docs = [
+    "sphinx",
+    "furo",
+]
+test = [
+    "pre-commit",
+    "pytest<7",
+    "mypy>=0.942",
+]
+style = [
+    "black==22.3.0",
+    "isort>=5.10.1",
+    "flake8>=3.8.3",
+]
+
+[project.urls]
+repository = "https://github.com/MrMino/wheelfile"
+documentation = "https://wheelfile.readthedocs.io/en/latest/"
+changelog = "https://github.com/MrMino/wheelfile/CHANGELOG.md"
+
+[tool.isort]
+profile = "black"
+line_length = 79
+
+[tool.black]
+line-length = 79
+skip-string-normalization = true
+include = '\.pyi?$'
+exclude = '''
+(
+    /(
+        | \.git
+        | \.mypy_cache
+        | \.pytest_cache
+        | build
+        | dist
+    )
+)
+'''
+
+[tool.mypy]
+# warn_redundant_casts = true
+# warn_unused_ignores = true
+# disallow_untyped_defs = true
+# ignore_missing_imports = true
+mypy_path = "stubs"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
--r requirements.txt
-
-# Documentation
--r docs/requirements.txt
-
-# Tests
-pre-commit
-pytest
-mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-packaging ~= 20.8
-zipfile38 ; python_version<"3.8"

--- a/wheelfile.py
+++ b/wheelfile.py
@@ -60,7 +60,7 @@ else:
 
 from typing import Optional, Union, List, Dict, IO, BinaryIO
 
-__version__ = '0.0.8'
+__version__ = '0.0.8-1'
 
 
 # TODO: ensure that writing into `file` arcname and then into `file/not/really`


### PR DESCRIPTION
@MrMino I updated the build to use your example with a pyproject.toml. The requirements files are really intended for deployments anyway.

Also, is this project just for learning or you going to maintain it?